### PR TITLE
made write permissions check more flexible.

### DIFF
--- a/core/library/filesystem.php
+++ b/core/library/filesystem.php
@@ -51,14 +51,14 @@ class Filesystem {
 
 		$this->have_direct_access = false;
 
-		if ( !function_exists( 'getmyuid' ) || !function_exists( 'fileowner' ) ) {
+		if ( !function_exists( 'getmyuid' ) || !function_exists( 'fileowner' ) || !function_exists( 'posix_getgroups' ) || !function_exists( 'filegroup' ) ) {
 			return $this->have_direct_access;
 		}
 
 		$temp_file_name = $this->config->root_path . '/temp-write-test-' . time();
 		$temp_handle = @fopen( $temp_file_name, 'w' );
 		if ( $temp_handle ) {
-			if ( getmyuid() == @fileowner( $temp_file_name ) ) {
+			if ( getmyuid() == @fileowner( $temp_file_name ) || in_array( @filegroup( $temp_file_name ), posix_getgroups() )  ) {
 				$this->have_direct_access = true;
 			}
 			@fclose( $temp_handle );


### PR DESCRIPTION
added a check for temp-write-test files group & the php engine's groups.

in some situations; local development for some, apache(or other egine) may using the home folder as webroot. here apache may be in the main users group and will not own any files it creates. this means that leeflets may be able to write to filesystem but get false negative when only checking getmyuid() vs fileowner().

solved by adding check for filegroup() in posix_getgroups()
